### PR TITLE
Support for memory allocation from multiple NUMA nodes

### DIFF
--- a/arena.h
+++ b/arena.h
@@ -14,6 +14,8 @@
 #ifndef ARENA_H_INCLUDED
 #define ARENA_H_INCLUDED
 
+#define MAX_MEM_NODES (8*sizeof(uint64_t))
+
 void *alloc_arena_shm(size_t arena_size);
 void *alloc_arena_mmap(size_t arena_size);
 

--- a/multichase.c
+++ b/multichase.c
@@ -679,7 +679,8 @@ usage:
                                 "               the chase and before starting the benchmark (use with nta)\n"
                                 "               default: %zu\n", DEF_CACHE_FLUSH);
                 fprintf(stderr, "-W mbind list  list of node:weight,... pairs for allocating memory\n"
-                                "               has no effect if -H flag is specified\n");
+                                "               has no effect if -H flag is specified\n"
+                                "               0:10,1:90 weights it as 10%% on 0 and 90%% on 1\n");
                 fprintf(stderr, "-X             do not set thread affinity\n");
                 fprintf(stderr, "-y             print timestamp in front of each line\n");
                 exit(1);


### PR DESCRIPTION
Added support for multichase to allocate memory from multiple NUMA
nodes. The -W flag is used to set the weights for the nodes that
memory will be allocated from. For example, -W 0:100,1:200,2:100
will allocate 25% of memory from node 0, 50% from node 1, and 25%
from node 2.