### PR TITLE
fix compile bug in CentOS7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 CFLAGS=-std=gnu99 -g -O2 -fomit-frame-pointer -fno-unroll-loops -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -Wmissing-declarations -Wnested-externs -Wpointer-arith -W -Wno-unused-parameter -Werror -pthread
-LDFLAGS=-g -O2 -static -pthread
+LDFLAGS=-g -O2 -pthread
 LDLIBS=-lrt
 
 EXE=multichase fairness pingpong


### PR DESCRIPTION
In Ubuntu, there is static library of libpthread.a librt.a libc.a in /usr/lib/x86_64-linux-gnu/ default,
But in CentOS, there is not static library of libpthread.a librt.a libc.a default, you must specific it
with -L/usr/lib/x86_64-redhat-linux6E/lib64/ which contains the static library