### PR TITLE
AARCH64 lse support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,15 @@ CFLAGS=-std=gnu99 -g -O2 -fomit-frame-pointer -fno-unroll-loops -Wall -Wstrict-p
 LDFLAGS=-g -O2 -static -pthread
 LDLIBS=-lrt
 
+ARCH := $(shell uname -m)
+
+ifeq ($(ARCH),aarch64)
+ CAP := $(shell cat /proc/cpuinfo | grep atomics | head -1)
+ ifneq (,$(findstring atomics,$(CAP)))
+  CFLAGS+=-march=armv8.1-a+lse
+ endif
+endif
+
 EXE=multichase fairness pingpong
 
 all: $(EXE)


### PR DESCRIPTION
When building for aarch64, check capabilities for atomics, and if exist, add lse to compile flags