### PR TITLE
Fix compiler warnings. Dynamically allocate weights_cumsum instead of

### DIFF
--- a/arena.c
+++ b/arena.c
@@ -72,6 +72,7 @@ static void arena_weighted_mbind(void *arena, size_t arena_size,
 		}
 		*p = 0;
 	}
+	free(weights_cumsum);
 }
 
 void *alloc_arena_mmap(size_t arena_size)

--- a/arena.c
+++ b/arena.c
@@ -42,7 +42,11 @@ static void arena_weighted_mbind(void *arena, size_t arena_size,
 	 * the method for determining a hit on a weight i is when the generated
 	 * random number (modulo sum of weights) <= weights_cumsum[i]
 	 */
-	int64_t weights_cumsum[nr_weights];
+	int64_t *weights_cumsum = malloc(nr_weights*sizeof(int64_t));
+	if (!weights_cumsum) {
+		fprintf(stderr, "Couldn't allocate memory for weights.\n");
+		exit(1);
+	}
 	weights_cumsum[0] = weights[0] - 1;
 	for (unsigned int i = 1; i < nr_weights; i++) {
 		weights_cumsum[i] = weights_cumsum[i-1] + weights[i];

--- a/permutation.h
+++ b/permutation.h
@@ -85,7 +85,7 @@ static inline void rng_init(unsigned thread_num)
 
 static inline perm_t rng_int(perm_t limit)
 {
-        int r;
+        int r = 0;
         assert(random_r(rand_state, &r) == 0);
         // much more uniform to use [0.,1.) multiply than use an integer modulus
         return (limit + 1) * (r * 1.0 / RAND_MAX);

--- a/permutation.h
+++ b/permutation.h
@@ -80,13 +80,19 @@ static inline void rng_init(unsigned thread_num)
         rng_buf = (char*)calloc(1, RNG_BUF_SIZE);
         rand_state = (struct random_data*)calloc(1, sizeof(struct random_data));
         assert(rand_state);
-        assert(initstate_r(thread_num, rng_buf, RNG_BUF_SIZE, rand_state) == 0);
+        if (initstate_r(thread_num, rng_buf, RNG_BUF_SIZE, rand_state) != 0) {
+                perror("initstate_r");
+                exit(1);
+        }
 }
 
 static inline perm_t rng_int(perm_t limit)
 {
         int r = 0;
-        assert(random_r(rand_state, &r) == 0);
+        if (random_r(rand_state, &r) != 0) {
+                perror("random_r");
+                exit(1);
+        }
         // much more uniform to use [0.,1.) multiply than use an integer modulus
         return (limit + 1) * (r * 1.0 / RAND_MAX);
 }


### PR DESCRIPTION
relying on a variable length array.  Initialize a variable before use.