### PR TITLE
Ignore tautological compare compile time warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-CFLAGS=-std=gnu99 -g -O2 -fomit-frame-pointer -fno-unroll-loops -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -Wmissing-declarations -Wnested-externs -Wpointer-arith -W -Wno-unused-parameter -Werror -pthread
+CFLAGS=-std=gnu99 -g -O2 -fomit-frame-pointer -fno-unroll-loops -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -Wmissing-declarations -Wnested-externs -Wpointer-arith -W -Wno-unused-parameter -Werror -pthread -Wno-tautological-compare
 LDFLAGS=-g -O2 -static -pthread
 LDLIBS=-lrt
 


### PR DESCRIPTION
On Ubuntu 18 with gcc-7 this warning breaks compilation due to -Werror.  Fix is to ignore this particular type of error

```
cc -std=gnu99 -g -O2 -fomit-frame-pointer -fno-unroll-loops -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -Wmissing-declarations -Wnested-externs -Wpointer-arith -W -Wno-unused-parameter -Werror -pthread   -c -o multichase.o multichase.c
multichase.c: In function ‘main’:
multichase.c:717:82: error: self-comparison always evaluates to false [-Werror=tautological-compare]
                 && ((uint64_t)genchase_args.total_memory / genchase_args.stride) != (genchase_args.total_memory / genchase_args.stride)) {
                                                                                  ^~
cc1: all warnings being treated as errors
<builtin>: recipe for target 'multichase.o' failed
make: *** [multichase.o] Error 1
```
