### PR TITLE
cross-compiler support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ CFLAGS=-std=gnu99 -g -O3 -fomit-frame-pointer -fno-unroll-loops -Wall -Wstrict-p
 LDFLAGS=-g -O3 -static -pthread
 LDLIBS=-lrt -lm
 
-ARCH := $(shell uname -m)
+ARCH ?= $(shell uname -m)
 
 ifeq ($(ARCH),aarch64)
- CAP := $(shell cat /proc/cpuinfo | grep atomics | head -1)
+ CAP ?= $(shell cat /proc/cpuinfo | grep atomics | head -1)
  ifneq (,$(findstring atomics,$(CAP)))
   CFLAGS+=-march=armv8.1-a+lse
  endif


### PR DESCRIPTION
For cross compile, the ARCH variable should be passed as input parameter instead of the Makefile evaluating the host architecture. Also, the target CPU's capability should be specified by the makefile parameter as it cannot be dynamically evaluated for cross compilation.