### PR TITLE
Dax support

### DIFF
--- a/arena.h
+++ b/arena.h
@@ -24,6 +24,6 @@ size_t get_native_page_size(void);
 bool page_size_is_huge(size_t page_size);
 void print_page_size(size_t page_size, bool use_thp);
 
-void *alloc_arena_mmap(size_t page_size, bool use_thp, size_t arena_size);
+void *alloc_arena_mmap(size_t page_size, bool use_thp, size_t arena_size, int fd);
 
 #endif

--- a/multichase.c
+++ b/multichase.c
@@ -757,7 +757,7 @@ int main(int argc, char **argv) {
 
   rng_init(1);
 
-  generate_chase_mixer(&genchase_args);
+  generate_chase_mixer(&genchase_args, nr_threads * chase->parallelism);
 
   // generate the chases by launching multiple threads
   genchase_args.arena =

--- a/multichase.c
+++ b/multichase.c
@@ -860,6 +860,4 @@ int main(int argc, char **argv) {
   printf("%6.*f\n", res < 100. ? 3 : 1, res);
 
   exit(0);
-
-  return 0;
 }

--- a/multichase.c
+++ b/multichase.c
@@ -735,15 +735,6 @@ int main(int argc, char **argv) {
         genchase_args.total_memory % genchase_args.tlb_locality;
   }
 
-  if (sizeof(perm_t) < sizeof(size_t) &&
-      ((uint64_t)genchase_args.total_memory / genchase_args.stride) !=
-          (genchase_args.total_memory / genchase_args.stride)) {
-    fprintf(stderr,
-            "too many elements required -- maximum supported is %" PRIu64 "\n",
-            (UINT64_C(1) << 8 * sizeof(perm_t)));
-    exit(1);
-  }
-
   genchase_args.nr_mixer_indices =
       genchase_args.stride / chase->base_object_size;
   if (genchase_args.nr_mixer_indices < nr_threads * chase->parallelism) {

--- a/multiload.c
+++ b/multiload.c
@@ -1116,7 +1116,7 @@ int main(int argc, char **argv) {
   rng_init(1);
 
   if (run_test_type != RUN_BANDWIDTH) {
-    generate_chase_mixer(&genchase_args);
+    generate_chase_mixer(&genchase_args, nr_threads * chase->parallelism);
 
     // generate the chases by launching multiple threads
     if (verbosity > 2) printf("allocate genchase_args.arena\n");

--- a/multiload.c
+++ b/multiload.c
@@ -730,8 +730,8 @@ static void *thread_start(void *data) {
     // generate buffers
     args->x.load_arena = (char *)alloc_arena_mmap(
                              page_size, use_thp,
-                             args->x.load_total_memory + args->x.load_offset) +
-                         args->x.load_offset;
+                             args->x.load_total_memory + args->x.load_offset,
+                             -1) + args->x.load_offset;
     memset(args->x.load_arena, 1,
            args->x.load_total_memory);  // ensure pages are mapped
   }
@@ -1131,15 +1131,16 @@ int main(int argc, char **argv) {
     if (verbosity > 2) printf("allocate genchase_args.arena\n");
     genchase_args.arena =
         (char *)alloc_arena_mmap(page_size, use_thp,
-                                 genchase_args.total_memory + offset) +
+                                 genchase_args.total_memory + offset, -1) +
         offset;
   }
   per_thread_t *thread_data = alloc_arena_mmap(
-      default_page_size, false, nr_threads * sizeof(per_thread_t));
+      default_page_size, false, nr_threads * sizeof(per_thread_t), -1);
   void *flush_arena = NULL;
   if (verbosity > 2) printf("allocate cache flush\n");
   if (cache_flush_size) {
-    flush_arena = alloc_arena_mmap(default_page_size, false, cache_flush_size);
+    flush_arena = alloc_arena_mmap(default_page_size, false, cache_flush_size,
+                                   -1);
     memset(flush_arena, 1, cache_flush_size);  // ensure pages are mapped
   }
 

--- a/multiload.c
+++ b/multiload.c
@@ -1086,15 +1086,6 @@ int main(int argc, char **argv) {
         genchase_args.total_memory % genchase_args.tlb_locality;
   }
 
-  if (sizeof(perm_t) < sizeof(size_t) &&
-      ((uint64_t)genchase_args.total_memory / genchase_args.stride) !=
-          (genchase_args.total_memory / genchase_args.stride)) {
-    fprintf(stderr,
-            "too many elements required -- maximum supported is %" PRIu64 "\n",
-            (UINT64_C(1) << 8 * sizeof(perm_t)));
-    exit(1);
-  }
-
   genchase_args.nr_mixer_indices =
       genchase_args.stride / chase->base_object_size;
   if ((run_test_type == RUN_CHASE) &&

--- a/permutation.c
+++ b/permutation.c
@@ -171,7 +171,6 @@ void *generate_chase(const struct generate_chase_common_args *args,
   for (i = 0; i < nr_elts; ++i) {
     size_t next;
     dassert(perm[perm_inverse[i]] == i);
-    assert(*(void **)(arena + MIXED(i)) == NULL);
     next = perm_inverse[i] + 1;
     next = (next == nr_elts) ? 0 : next;
     *(void **)(arena + MIXED(i)) = (void *)(arena + MIXED(perm[next]));

--- a/permutation.c
+++ b/permutation.c
@@ -14,6 +14,7 @@
 #include "permutation.h"
 
 #include <assert.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -88,23 +89,26 @@ int is_a_permutation(const perm_t *perm, size_t nr_elts) {
   return 1;
 }
 
-// power-of-2 number of mixer permutations
-#define NR_MIXERS (16384)
-
-void generate_chase_mixer(struct generate_chase_common_args *args) {
+void generate_chase_mixer(struct generate_chase_common_args *args,
+                          size_t nr_mixers) {
   size_t nr_mixer_indices = args->nr_mixer_indices;
   void (*gen_permutation)(perm_t *, size_t, size_t) = args->gen_permutation;
 
+  /* Set number of mixers rounded up to the power of two */
+  args->nr_mixers = 1 << (CHAR_BIT * sizeof(long) -
+                          __builtin_clzl(nr_mixers - 1));
+  if (verbosity > 1)
+    printf("nr_mixers = %zu\n", args->nr_mixers);
   perm_t *t = malloc(nr_mixer_indices * sizeof(*t));
   if (t == NULL) {
     fprintf(stderr, "Could not allocate %lu bytes, check stride/memory size?\n",
             nr_mixer_indices * sizeof(*t));
     exit(1);
   }
-  perm_t *r = malloc(nr_mixer_indices * NR_MIXERS * sizeof(*r));
+  perm_t *r = malloc(nr_mixer_indices * args->nr_mixers * sizeof(*r));
   if (r == NULL) {
     fprintf(stderr, "Could not allocate %lu bytes, check stride/memory size?\n",
-            nr_mixer_indices * NR_MIXERS * sizeof(*r));
+            nr_mixer_indices * args->nr_mixers * sizeof(*r));
     exit(1);
   }
   size_t i;
@@ -112,10 +116,10 @@ void generate_chase_mixer(struct generate_chase_common_args *args) {
 
   // we arrange r in a transposed manner so that all of the
   // data for a particular mixer_idx is packed together.
-  for (i = 0; i < NR_MIXERS; ++i) {
+  for (i = 0; i < args->nr_mixers; ++i) {
     gen_permutation(t, nr_mixer_indices, 0);
     for (j = 0; j < nr_mixer_indices; ++j) {
-      r[j * NR_MIXERS + i] = t[j];
+      r[j * args->nr_mixers + i] = t[j];
     }
   }
   free(t);
@@ -130,7 +134,7 @@ void *generate_chase(const struct generate_chase_common_args *args,
   size_t stride = args->stride;
   size_t tlb_locality = args->tlb_locality;
   void (*gen_permutation)(perm_t *, size_t, size_t) = args->gen_permutation;
-  const perm_t *mixer = args->mixer + mixer_idx * NR_MIXERS;
+  const perm_t *mixer = args->mixer + mixer_idx * args->nr_mixers;
   size_t nr_mixer_indices = args->nr_mixer_indices;
 
   size_t nr_tlb_groups = total_memory / tlb_locality;
@@ -164,7 +168,7 @@ void *generate_chase(const struct generate_chase_common_args *args,
 
   dassert(is_a_permutation(perm_inverse, nr_elts));
 
-#define MIXED(x) ((x)*stride + mixer[(x) & (NR_MIXERS - 1)] * mixer_scale)
+#define MIXED(x) ((x)*stride + mixer[(x) & (args->nr_mixers - 1)] * mixer_scale)
 
   if (verbosity > 1)
     printf("threading the chase (mixer_idx = %zu)\n", mixer_idx);

--- a/permutation.h
+++ b/permutation.h
@@ -49,6 +49,8 @@ struct generate_chase_common_args {
   size_t stride;        // size of each element
   size_t tlb_locality;  // group accesses within this range in order to
                         // amortize TLB fills
+  size_t nr_mixers;     // Rounded up to power of two number of mixers:
+                        // nr_threads * parallelism rounded up to power of two
   void (*gen_permutation)(perm_t *, size_t,
                           size_t);  // function for generating
                                     // permutations
@@ -59,7 +61,8 @@ struct generate_chase_common_args {
 };
 
 // create the mixer table
-void generate_chase_mixer(struct generate_chase_common_args *args);
+void generate_chase_mixer(struct generate_chase_common_args *args,
+                          size_t nr_mixers);
 
 // create a chase for the given mixer_idx and return its first pointer
 void *generate_chase(const struct generate_chase_common_args *args,


### PR DESCRIPTION
A set of patches:
1. Allow allocation from file
2. Increase the size of chase array by changing perm_t to size_t, and also improve randomness by covering full 64-bit space instead of 30-bit space
3. Allow large strides via scalable nr_mixers.