### PR TITLE
Allow to build with c++

### DIFF
--- a/fairness.c
+++ b/fairness.c
@@ -11,7 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <errno.h>
 #include <inttypes.h>
 #include <math.h>
@@ -66,7 +68,7 @@ static void wait_for_startup(void) {
 }
 
 static void *worker(void *_args) {
-  per_thread_t *args = _args;
+  per_thread_t *args = (per_thread_t *)_args;
 
   // move to our target cpu
   cpu_set_t cpu;
@@ -162,7 +164,8 @@ int main(int argc, char **argv) {
     }
   }
 
-  per_thread_t *thread_args = calloc(nr_threads, sizeof(*thread_args));
+  per_thread_t *thread_args = (per_thread_t *)calloc(nr_threads,
+      sizeof(*thread_args));
   nr_to_startup = nr_threads + 1;
   size_t u;
   i = 0;
@@ -182,7 +185,7 @@ int main(int argc, char **argv) {
 
   wait_for_startup();
 
-  atomic_t *samples = calloc(nr_threads, sizeof(*samples));
+  atomic_t *samples = (atomic_t *)calloc(nr_threads, sizeof(*samples));
 
   printf(
       "results are avg latency per locked increment in ns, one column per "

--- a/permutation.h
+++ b/permutation.h
@@ -19,6 +19,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#if !defined __cplusplus
+#define static_assert _Static_assert
+#endif
+
 typedef size_t perm_t;
 
 void gen_random_permutation(perm_t *perm, size_t nr, size_t base);
@@ -107,7 +111,7 @@ static inline perm_t rng_int(perm_t limit) {
     exit(1);
   }
   // Assume that RAND_MAX is at least 16-bit long
-  _Static_assert (RAND_MAX >= (1ul << 16), "RAND_MAX is too small");
+  static_assert (RAND_MAX >= (1ul << 16), "RAND_MAX is too small");
   r = (((uint64_t)r1 <<  0) & 0x000000000000FFFFull) |
       (((uint64_t)r2 << 16) & 0x00000000FFFF0000ull) |
       (((uint64_t)r3 << 32) & 0x0000FFFF00000000ull) |


### PR DESCRIPTION
In order to be able to statically compile multichase with tcmalloc it must be buildtable with a C++ compiler. This is because tcmalloc is itself written in C++.

The changes mostly involve removing implict casting from void * to any type, and instead specify the type.

With the change it is possible to compile with clang++ and g++:

G++ build:
$ make clean && make CC=g++  CFLAGS="-w"
rm -f multichase multiload fairness pingpong *.o expand.h ./gen_expand 200 >expand.h.tmp
g++ -w   -c -o permutation.o permutation.c
g++ -w   -c -o arena.o arena.c
g++ -w   -c -o util.o util.c
g++ -w   -c -o pingpong.o pingpong.c
mv expand.h.tmp expand.h
g++ -w   -c -o multichase.o multichase.c
g++ -w   -c -o multiload.o multiload.c
g++ -w   -c -o fairness.o fairness.c
g++ -g -O3 -static -pthread  pingpong.o  -lrt -lm -o pingpong
g++ -g -O3 -static -pthread  fairness.o  -lrt -lm -lm -o fairness
g++ -g -O3 -static -pthread  multichase.o permutation.o arena.o util.o  -lrt -lm -o multichase
g++ -g -O3 -static -pthread  multiload.o permutation.o arena.o util.o  -lrt -lm -o multiload

clang++ build:
make clean && make CC=clang++  CFLAGS="-Wno-everything" rm -f multichase multiload fairness pingpong *.o expand.h ./gen_expand 200 >expand.h.tmp
clang++ -Wno-everything   -c -o permutation.o permutation.c
clang++ -Wno-everything   -c -o arena.o arena.c
clang++ -Wno-everything   -c -o util.o util.c
clang++ -Wno-everything   -c -o pingpong.o pingpong.c
mv expand.h.tmp expand.h
clang++ -Wno-everything   -c -o multichase.o multichase.c
clang++ -Wno-everything   -c -o multiload.o multiload.c
clang++ -Wno-everything   -c -o fairness.o fairness.c
clang++ -g -O3 -static -pthread  pingpong.o  -lrt -lm -o pingpong
clang++ -g -O3 -static -pthread  fairness.o  -lrt -lm -lm -o fairness
clang++ -g -O3 -static -pthread  multichase.o permutation.o arena.o util.o  -lrt -lm -o multichase
clang++ -g -O3 -static -pthread  multiload.o permutation.o arena.o util.o  -lrt -lm -o multiload