### PR TITLE
Add a flag to set nr_mixers; change default back to 16384

### DIFF
--- a/multichase.c
+++ b/multichase.c
@@ -50,6 +50,7 @@
 #define DEF_TOTAL_MEMORY ((size_t)256 * 1024 * 1024)
 #define DEF_STRIDE ((size_t)256)
 #define DEF_NR_SAMPLES ((size_t)5)
+#define DEF_NR_MIXERS ((size_t)16384)
 #define DEF_TLB_LOCALITY ((size_t)64)
 #define DEF_NR_THREADS ((size_t)1)
 #define DEF_CACHE_FLUSH ((size_t)64 * 1024 * 1024)
@@ -514,10 +515,11 @@ int main(int argc, char **argv) {
   genchase_args.stride = DEF_STRIDE;
   genchase_args.tlb_locality = DEF_TLB_LOCALITY * default_page_size;
   genchase_args.gen_permutation = gen_random_permutation;
+  genchase_args.nr_mixers = DEF_NR_MIXERS;
 
   setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
 
-  while ((c = getopt(argc, argv, "ac:F:p:HLm:n:oO:S:s:T:t:vXyW:f:M")) != -1) {
+  while ((c = getopt(argc, argv, "ac:F:p:HLm:n:oO:R:S:s:T:t:vXyW:f:M")) != -1) {
     switch (c) {
       case 'a':
         print_average = 1;
@@ -612,6 +614,13 @@ int main(int argc, char **argv) {
       case 'o':
         genchase_args.gen_permutation = gen_ordered_permutation;
         break;
+      case 'R':
+        if (parse_mem_arg(optarg, &genchase_args.nr_mixers)) {
+          fprintf(stderr,
+                  "nr_mixers must be a positive integer\n");
+          exit(1);
+        }
+        break;
       case 's':
         if (parse_mem_arg(optarg, &genchase_args.stride)) {
           fprintf(
@@ -699,6 +708,8 @@ int main(int argc, char **argv) {
     fprintf(stderr,
             "               NOTE: TLB locality will be rounded down to a "
             "multiple of stride\n");
+    fprintf(stderr, "-R nr_mixers   value of nr_mixers (default %zu)\n",
+            DEF_NR_MIXERS);
     fprintf(stderr, "-t nr_threads  number of threads (default %zu)\n",
             DEF_NR_THREADS);
     fprintf(stderr, "-p page_size   backing page size to use (default %zu)\n",
@@ -779,7 +790,7 @@ int main(int argc, char **argv) {
 
   rng_init(1);
 
-  generate_chase_mixer(&genchase_args, nr_threads * chase->parallelism);
+  generate_chase_mixer(&genchase_args);
 
   // generate the chases by launching multiple threads
   if (use_malloc) {

--- a/permutation.c
+++ b/permutation.c
@@ -14,7 +14,6 @@
 #include "permutation.h"
 
 #include <assert.h>
-#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -90,14 +89,10 @@ int is_a_permutation(const perm_t *perm, size_t nr_elts) {
   return 1;
 }
 
-void generate_chase_mixer(struct generate_chase_common_args *args,
-                          size_t nr_mixers) {
+void generate_chase_mixer(struct generate_chase_common_args *args) {
   size_t nr_mixer_indices = args->nr_mixer_indices;
   void (*gen_permutation)(perm_t *, size_t, size_t) = args->gen_permutation;
 
-  /* Set number of mixers rounded up to the power of two */
-  args->nr_mixers = 1 << (CHAR_BIT * sizeof(long) -
-                          __builtin_clzl(nr_mixers - 1));
   if (verbosity > 1)
     printf("nr_mixers = %zu\n", args->nr_mixers);
   perm_t *t = malloc(nr_mixer_indices * sizeof(*t));

--- a/permutation.h
+++ b/permutation.h
@@ -61,8 +61,7 @@ struct generate_chase_common_args {
 };
 
 // create the mixer table
-void generate_chase_mixer(struct generate_chase_common_args *args,
-                          size_t nr_mixers);
+void generate_chase_mixer(struct generate_chase_common_args *args);
 
 // create a chase for the given mixer_idx and return its first pointer
 void *generate_chase(const struct generate_chase_common_args *args,


### PR DESCRIPTION
Lower value of nr_mixers makes single thread multichase inaccurate with the presence of region based prefetchers. It also causes set associativity issues with larger stride sizes (e.g. page_size) which leads to inaccurate results in performance analysis. Since there might be other potential side-effects of changing nr_mixers, we changed its default value back to 16384, and added a flag to set nr_mixers separately.