### PR TITLE
Set nr_mixers to be at least 64

### DIFF
--- a/permutation.c
+++ b/permutation.c
@@ -98,6 +98,8 @@ void generate_chase_mixer(struct generate_chase_common_args *args,
   /* Set number of mixers rounded up to the power of two */
   args->nr_mixers = 1 << (CHAR_BIT * sizeof(long) -
                           __builtin_clzl(nr_mixers - 1));
+  if (args->nr_mixers < 64) args->nr_mixers = 64;
+
   if (verbosity > 1)
     printf("nr_mixers = %zu\n", args->nr_mixers);
   perm_t *t = malloc(nr_mixer_indices * sizeof(*t));

--- a/permutation.c
+++ b/permutation.c
@@ -98,7 +98,9 @@ void generate_chase_mixer(struct generate_chase_common_args *args,
   /* Set number of mixers rounded up to the power of two */
   args->nr_mixers = 1 << (CHAR_BIT * sizeof(long) -
                           __builtin_clzl(nr_mixers - 1));
-  if (args->nr_mixers < 64) args->nr_mixers = 64;
+  if (args->nr_mixers < 64) {
+    args->nr_mixers = 64;
+  }
 
   if (verbosity > 1)
     printf("nr_mixers = %zu\n", args->nr_mixers);


### PR DESCRIPTION
We are seeing unexpectedly low single thread chase latency with current code at head. Increasing nr_mixers to at 64 helps avoid this issue.