### PR TITLE
Add CMakeLists.txt to enable building with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.1...3.29)
+
+project(
+  multichase
+  VERSION 1.0
+  LANGUAGES C)
+
+add_custom_command(
+  OUTPUT expand.h
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/gen_expand 200 > expand.h
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_expand
+  VERBATIM
+)
+
+add_library(common
+  br_asm.c
+  permutation.c
+  arena.c
+  util.c
+  cpu_util.h
+  timer.h
+  permutation.h
+  util.h
+  arena.h
+  expand.h
+)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+add_executable(multichase multichase.c)
+target_link_libraries(multichase PRIVATE common)
+target_link_libraries(multichase PRIVATE m)
+
+add_executable(multiload multiload.c)
+target_link_libraries(multiload PRIVATE common)
+target_link_libraries(multiload PRIVATE m)
+
+add_executable(fairness multiload.c)
+target_link_libraries(fairness PRIVATE common)
+target_link_libraries(fairness PRIVATE m)
+
+add_executable(pingpong multiload.c)
+target_link_libraries(pingpong PRIVATE common)
+target_link_libraries(pingpong PRIVATE m)

--- a/README
+++ b/README
@@ -1,11 +1,17 @@
 Multichase - a pointer chaser benchmark
 Multiload - a superset of multichase which runs latency, memory bandwidth, and loaded-latency
 
-1/ BUILD
+1/ BUILD (make)
 
    - just type:
 
      $ make
+
+   BUILD (cmake)
+
+   - cmake -S . build
+   - cd build
+   - make
 
 2/ INSTALL
 


### PR DESCRIPTION
Add CMakeLists.txt to facilitate building with cmake allowing for simpler cross compiling.

To build natively:
 $ cmake -S . build
 $ cd build && make

To build using a toolchain:
 $ cmake -S . build \
  -DCMAKE_TOOLCHAIN_FILE=aarch64-linux-gnu.toolchain.cmake
 $ cd build && make