### PR TITLE
Fix underfined behavior of generate_chase_mixer when nr_mixers is 1

### DIFF
--- a/permutation.c
+++ b/permutation.c
@@ -96,8 +96,11 @@ void generate_chase_mixer(struct generate_chase_common_args *args,
   void (*gen_permutation)(perm_t *, size_t, size_t) = args->gen_permutation;
 
   /* Set number of mixers rounded up to the power of two */
-  args->nr_mixers = 1 << (CHAR_BIT * sizeof(long) -
-                          __builtin_clzl(nr_mixers - 1));
+  if (nr_mixer > 1) {
+    args->nr_mixers = 1 << (CHAR_BIT * sizeof(long) -
+                            __builtin_clzl(nr_mixers - 1));
+  }
+  
   if (args->nr_mixers < 64) {
     args->nr_mixers = 64;
   }


### PR DESCRIPTION
generate_chase_mixer rounds up nr_mixers to the power of two by using __builtin_clzl(nr_mixers -1). As __builtin_clzl(0) is undefined, the result is underministic when nr_mixers is 1. This fix applies the round up only when nr_mixers is larger than 1.