### PR TITLE
Revert "Fix underfined behavior of generate_chase_mixer when nr_mixers is 1"

### DIFF
--- a/permutation.c
+++ b/permutation.c
@@ -96,11 +96,8 @@ void generate_chase_mixer(struct generate_chase_common_args *args,
   void (*gen_permutation)(perm_t *, size_t, size_t) = args->gen_permutation;
 
   /* Set number of mixers rounded up to the power of two */
-  if (nr_mixer > 1) {
-    args->nr_mixers = 1 << (CHAR_BIT * sizeof(long) -
-                            __builtin_clzl(nr_mixers - 1));
-  }
-  
+  args->nr_mixers = 1 << (CHAR_BIT * sizeof(long) -
+                          __builtin_clzl(nr_mixers - 1));
   if (args->nr_mixers < 64) {
     args->nr_mixers = 64;
   }


### PR DESCRIPTION
Reverts google/multichase#43; the patch has a typo in the variable name and breaks the compilation