### PR TITLE
Update the undeclared variable error caused due to nr_mixer argument

### DIFF
--- a/permutation.c
+++ b/permutation.c
@@ -96,7 +96,7 @@ void generate_chase_mixer(struct generate_chase_common_args *args,
   void (*gen_permutation)(perm_t *, size_t, size_t) = args->gen_permutation;
 
   /* Set number of mixers rounded up to the power of two */
-  if (nr_mixer > 1) {
+  if (nr_mixers > 1) {
     args->nr_mixers = 1 << (CHAR_BIT * sizeof(long) -
                             __builtin_clzl(nr_mixers - 1));
   }


### PR DESCRIPTION
We are facing the following error while executing the benchmark

```
permutation.c:99:7: error: 'nr_mixer' undeclared (first use in this function); did you mean 'nr_mixers'?
   99 |   if (nr_mixer > 1) {
      |       ^~~~~~~~
      |       nr_mixers
```