### PR TITLE
Fix typo: change 'nr_mixer' to 'nr_mixers' in permutation.c

### DIFF
--- a/permutation.c
+++ b/permutation.c
@@ -96,7 +96,7 @@ void generate_chase_mixer(struct generate_chase_common_args *args,
   void (*gen_permutation)(perm_t *, size_t, size_t) = args->gen_permutation;
 
   /* Set number of mixers rounded up to the power of two */
-  if (nr_mixer > 1) {
+  if (nr_mixers > 1) {
     args->nr_mixers = 1 << (CHAR_BIT * sizeof(long) -
                             __builtin_clzl(nr_mixers - 1));
   }

--- a/permutation.c
+++ b/permutation.c
@@ -99,6 +99,8 @@ void generate_chase_mixer(struct generate_chase_common_args *args,
   if (nr_mixers > 1) {
     args->nr_mixers = 1 << (CHAR_BIT * sizeof(long) -
                             __builtin_clzl(nr_mixers - 1));
+  } else {
+    args->nr_mixers = 1;
   }
   
   if (args->nr_mixers < 64) {


### PR DESCRIPTION
Problem
The recent typo fix in generate_chase_mixer() introduced a regression where args->nr_mixers remains uninitialized when nr_mixers <= 1.
Root cause:

When nr_mixers = 1, the condition (nr_mixers > 1) is false
args->nr_mixers keeps its garbage value (observed: 5009408)
This triggers massive memory allocation attempts (~144TB)

Solution
Add an else branch to properly initialize args->nr_mixers = 1 when nr_mixers <= 1.

Testing

 Verified with nr_mixers = 1 case
 Confirmed proper memory allocation (64 mixers minimum)
 No regression in nr_mixers > 1 cases

Fixes

Fixes regression introduced in commit bee35359ad21
Resolves compilation error in permutation.c:99
<img width="1646" alt="output (1)" src="https://github.com/user-attachments/assets/6b23c73d-8a03-4368-a4ef-11e7cdce15ff" />
<img width="1702" alt="output (2)" src="https://github.com/user-attachments/assets/8351b303-6c7b-411d-bb34-a5f73101c7e4" />
<img width="1015" alt="output (3)" src="https://github.com/user-attachments/assets/e2a38afa-efff-4298-a6cf-133e9c388daa" />

