### PR TITLE
Try to add support code for riscv64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,13 @@ ifeq ($(ARCH),aarch64)
  endif
 endif
 
+ifeq ($(ARCH),riscv64)
+ CAP ?= $(shell cat /proc/cpuinfo | grep -E 'zihintpause' | head -1)
+ ifneq (,$(findstring zihintpause,$(CAP)))
+  CFLAGS+=-march=rv64gc_zihintpause
+ endif
+endif
+
 EXE=multichase multiload fairness pingpong
 
 all: $(EXE)

--- a/cpu_util.h
+++ b/cpu_util.h
@@ -40,6 +40,8 @@ static inline void cpu_relax(void) {
 }
 #elif defined(__aarch64__)
 #define cpu_relax() asm volatile("yield" ::: "memory")
+#elif defined(__riscv) && __riscv_xlen == 64
+#define cpu_relax() asm volatile("pause" ::: "memory")
 #else
 #warning "no cpu_relax for your cpu"
 #define cpu_relax() \

--- a/multichase.c
+++ b/multichase.c
@@ -492,6 +492,12 @@ static void *thread_start(void *data) {
         args->x.genchase_args->arena,
         args->x.genchase_args->arena + args->x.genchase_args->total_memory);
 #endif
+#if defined(__riscv) && __riscv_xlen == 64
+    __builtin___clear_cache(
+        args->x.genchase_args->arena,
+        args->x.genchase_args->arena + args->x.genchase_args->total_memory);
+#endif
+
   }
   
   // now flush our caches

--- a/multichase.c
+++ b/multichase.c
@@ -487,12 +487,7 @@ static void *thread_start(void *data) {
   if (!strcmp(args->x.chase->name, "branch")) {
     void *p = args->x.cycle[0];
     args->x.branch_chunk_size = convert_pointers_to_branches(p, 200);
-#if defined(__aarch64__)
-    __builtin___clear_cache(
-        args->x.genchase_args->arena,
-        args->x.genchase_args->arena + args->x.genchase_args->total_memory);
-#endif
-#if defined(__riscv) && __riscv_xlen == 64
+#if defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64)
     __builtin___clear_cache(
         args->x.genchase_args->arena,
         args->x.genchase_args->arena + args->x.genchase_args->total_memory);

--- a/multiload.c
+++ b/multiload.c
@@ -601,6 +601,14 @@ static void load_stream_triad_nontemporal_injection_delay(per_thread_t *t) {
       if (i % num_elem_twocachelines == 0) delay_until_iteration(t->x.delay);
 #if defined(__aarch64__)
       asm volatile ("stnp %0, %1, [%2]" :: "r"(b[i]+c[i]), "r"(b[i+1]+c[i+1]), "r" (a+i));
+#elif defined(__riscv) && __riscv_xlen == 64
+      asm volatile ("sd %0, (%2)\n\t"
+              "sd %1, 8(%2)"
+              : // no outputs
+              : "r"(b[i]+c[i]),
+                "r"(b[i+1]+c[i+1]),
+                "r" (a+i)
+              : "memory");
 #elif defined(__x86_64__)
       _mm_stream_si64(&((long long*)a)[i], b[i]+c[i]);
       _mm_stream_si64(&((long long*)a)[i+1], b[i+1]+c[i+1]);

--- a/multiload.c
+++ b/multiload.c
@@ -602,6 +602,9 @@ static void load_stream_triad_nontemporal_injection_delay(per_thread_t *t) {
 #if defined(__aarch64__)
       asm volatile ("stnp %0, %1, [%2]" :: "r"(b[i]+c[i]), "r"(b[i+1]+c[i+1]), "r" (a+i));
 #elif defined(__riscv) && __riscv_xlen == 64
+      // sd (Store Doubleword) is a risc-v memory store instruction that stores a 64-bit (8-byte) value from a register to memory. 
+      // "sd %0, (%2)\n\t" stores 64-bit value from register %0 to memory address contained in register %2,
+      // "sd %1, 8(%2)" stores 64-bit value from register %1 to memory address [%2] + 8.
       asm volatile ("sd %0, (%2)\n\t"
               "sd %1, 8(%2)"
               : // no outputs


### PR DESCRIPTION
Add support code for riscv64, functionality tested and working on the Spacemit® X60 development board. Test logs are as follows.

<img width="1594" height="386" alt="image" src="https://github.com/user-attachments/assets/fd0d625d-e475-4aab-acf5-1b4b3a0fdb04" />
<img width="1590" height="207" alt="image" src="https://github.com/user-attachments/assets/2552c9bd-44ca-46a7-bbf1-6ea0702ad65e" />
<img width="1181" height="589" alt="image" src="https://github.com/user-attachments/assets/145b3e3d-fb95-4539-8b81-d5b12b207ab0" />
<img width="516" height="348" alt="image" src="https://github.com/user-attachments/assets/d3e9c99b-c724-4896-a457-086b27593957" />
<img width="1583" height="211" alt="image" src="https://github.com/user-attachments/assets/39a98582-ca09-4085-b4ac-0492a4ac5daf" />
<img width="1396" height="184" alt="image" src="https://github.com/user-attachments/assets/9ac17738-cc3a-40e9-9e5d-180d93a36ea4" />

