### PR TITLE
fix the scalar for load_stream_triad

### DIFF
--- a/multiload.c
+++ b/multiload.c
@@ -513,6 +513,7 @@ static void load_stream_triad(per_thread_t *t) {
   register double *b;
   register double *c;
   register double *tmp;
+  register double scalar = 3.0;
 
   load_loop =
       t->x.load_total_memory -
@@ -542,7 +543,7 @@ static void load_stream_triad(per_thread_t *t) {
     c = tmp;
 
     for (i = 0; i < N; ++i) {
-      a[i] = b[i] + c[i];
+      a[i] = b[i] + scalar * c[i];
     }
     LOAD_MEMORY_SAMPLE_MIBPS
   } while (1);


### PR DESCRIPTION
The stream triad should contain a scalar according to the description:
https://github.com/google/multichase/blob/ea9bd14678290ed1bd2ca2c897965e0f4ac3f888/multiload.c#L716

But the scalar is missing in the implementation which becomes a stream-add.