### PR TITLE
Fix documentation inconsistencies and remove dead options

### DIFF
--- a/README
+++ b/README
@@ -48,7 +48,7 @@ Multiload - a superset of multichase which runs latency, memory bandwidth, and l
 
   - Bandwidth Only
     Multiload can run a memory bandwidth test using the "-l" load argument. The "-c" chase argument MUST NOT be used.
-    Below command runs 5 samples (~2.5 seconds each), using 16 threads, using the glibc memcpy() function,
+    Below command runs 5 samples (2 seconds each), using 16 threads, using the glibc memcpy() function,
     using a 512M buffer per thread.
 
     $ multiload -n 5 -t 16 -m 512M -l memcpy-libc
@@ -56,7 +56,7 @@ Multiload - a superset of multichase which runs latency, memory bandwidth, and l
   - Loaded Latency.
     Multiload can run 1 pointer chaser thread on logical cpu0 with multiple memory bandwidth load threads.
     The "-c chaseload" arg MUST be used. The "-l" arg MUST be used with one of the memory load arguments.
-    Below command runs 5 samples (~2.5 seconds each), on 16 threads (1 chase, 15 stream-sum bandwidth loads),
+    Below command runs 5 samples (2 seconds each), on 16 threads (1 chase, 15 stream-sum bandwidth loads),
     using a 512M buffer per thread. The chase thread uses a stride=16.
 
     $ multiload -s 16 -n 5 -t 16 -m 512M -c chaseload -l stream-sum

--- a/fairness.c
+++ b/fairness.c
@@ -137,6 +137,7 @@ int main(int argc, char **argv) {
         " [-n sample_nr]\n"
         " [-s sweep_max]\n"
         " [-t time]\n"
+        " [-S separator]\n"
         "By default runs one thread on each cpu, use taskset(1) to "
         "restrict operation to fewer cpus/threads.\n"
         "The optional delay_mask specifies a mask of cpus on which to delay "
@@ -146,7 +147,8 @@ int main(int argc, char **argv) {
         "The optional sweep_max causes testing across multiple different "
         "cache lines.\n"
         "The optional time determines how often to poll results (float in "
-        "seconds).\n",
+        "seconds).\n"
+        "The optional separator determines the output field separator (e.g., ',' for CSV).\n",
         argv[0]);
     exit(1);
   }

--- a/multichase.c
+++ b/multichase.c
@@ -563,7 +563,7 @@ int main(int argc, char **argv) {
 
   setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
 
-  while ((c = getopt(argc, argv, "ac:F:p:HLm:Nn:oO:S:s:T:t:vXyW:f:M")) != -1) {
+  while ((c = getopt(argc, argv, "ac:F:p:HLm:Nn:oO:s:T:t:vXyW:f:M")) != -1) {
     switch (c) {
       case 'a':
         print_average = 1;
@@ -774,6 +774,7 @@ int main(int argc, char **argv) {
         "-W mbind list  list of node:weight,... pairs for allocating memory\n"
         "               has no effect if -H flag is specified\n"
         "               0:10,1:90 weights it as 10%% on 0 and 90%% on 1\n");
+    fprintf(stderr, "-v             verbose output (default %d)\n", verbosity);
     fprintf(stderr, "-X             do not set thread affinity\n");
     fprintf(stderr, "-y             print timestamp in front of each line\n");
     exit(1);

--- a/multiload.c
+++ b/multiload.c
@@ -921,7 +921,7 @@ int main(int argc, char **argv) {
 
   setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
 
-  while ((c = getopt(argc, argv, "ac:d:l:F:p:HLm:n:oO:S:s:T:t:vXyW:i:u:")) != -1) {
+  while ((c = getopt(argc, argv, "ac:d:l:F:p:HLm:n:oO:s:T:t:vXyW:i:u:")) != -1) {
     switch (c) {
       case 'a':
         print_average = 1;
@@ -1191,7 +1191,7 @@ int main(int argc, char **argv) {
     fprintf(stderr,
             "-L             use longer chase\n");
     fprintf(stderr,
-            "-n nr_samples  nr of 0.5 second samples to use (default %zu, 0 = "
+            "-n nr_samples  nr of 2.0 second samples to use (default %zu, 0 = "
             "infinite)\n",
             DEF_NR_SAMPLES);
     fprintf(stderr,


### PR DESCRIPTION
Fix documentation inconsistencies and remove dead options

This PR addresses several documentation inconsistencies and removes a dead option across the utilities:
1. **Correct Multiload Sample Duration:** 
   - Updated `multiload` help text and `README` to correctly state the sample duration is 2.0 seconds (matching `LOAD_DELAY_RUN_uS` which is set to 2,000,000 us), rather than the incorrect 0.5 seconds.
2. **Remove Dead `-S` Option:**
   - Removed `S:` from the `getopt` string in both `multichase.c` and `multiload.c`. The option was accepted by `getopt` but had no corresponding `case` in the switch statement, leading to silent failures/fallthroughs to usage help.
3. **Document Supported Options:**
   - Added the supported `-v` (verbosity) option to the `multichase` help message.
   - Added the supported `-S` (separator) option to the `fairness` usage and help description.