### PR TITLE
Fix 32-bit count wrap in chase counter

### DIFF
--- a/multichase.c
+++ b/multichase.c
@@ -78,7 +78,7 @@ typedef union {
   char pad[AVOID_FALSE_SHARING];
   struct {
     unsigned thread_num;        // which thread is this
-    unsigned count;             // count of number of iterations
+    uint64_t count;             // count of number of iterations
     void *cycle[MAX_PARALLEL];  // initial address for the chases
     const char *extra_args;
     int dummy;  // useful for confusing the compiler
@@ -493,7 +493,7 @@ static void *thread_start(void *data) {
         args->x.genchase_args->arena + args->x.genchase_args->total_memory);
 #endif
   }
-  
+
   // now flush our caches
   if (args->x.cache_flush_size) {
     size_t nr_elts = args->x.cache_flush_size / sizeof(size_t);


### PR DESCRIPTION
The per-thread chase counter was (32-bit), which wraps at 2^32 iterations. At high throughputs (>69 GB/s in a 500 ms sample) the counter wraps once or more, making the fastest pointer-chase runs report inflated latency.

Change the field to `uint64_t`, eliminating wrap on any realistic measurement window. `multiload.c` already had this fix (`volatile uint64_t count`).

---

## Results (Ryzen 7 7735HS, 1 thread, parallel10)

Below is the effective, core-centric bandwidth for a sweep across memory sizes, assuming bandwidth = 8 bytes / average latency (the value reported by `multichase`)

### Before 
Note the low reported performance in the L1, where the bandwidth is the highest, and where the counter overflows. The reported performance immediately shoots up when bandwidth drops below the overflow threshold.

<img width="1453" height="872" alt="image" src="https://github.com/user-attachments/assets/3a217a00-37f4-4606-9d50-a21462bd2e59" />

### After:
<img width="1453" height="872" alt="image" src="https://github.com/user-attachments/assets/c0035cb4-3a0b-41c0-8e0a-2f1a8be535f5" />

