### PR TITLE
fix(gen_expand): add numeric validation for input argument n

### DIFF
--- a/gen_expand
+++ b/gen_expand
@@ -15,10 +15,11 @@
 use warnings;
 use strict;
 
-defined(my $n = shift)
-        or die "usage: $0 n\n";
+my $n = shift;
+(defined($n) && $n =~ /^\d+$/ && $n >= 1)
+        or die "usage: $0 <positive_integer_n>\n";
 
-# special cases i can't be bothered to handle otherwise
+# special cases I can't be bothered to handle otherwise
 print "#define x1(x) x\n";
 print "#define x2(x) x x\n";
 print "#define x3(x) x2(x) x\n";


### PR DESCRIPTION
Executing ./gen_expand without arguments or with non-numeric parameters resulted in unhandled script errors and could produce malformed header files. This change validates that $n is a positive integer before proceeding, and fixes capitalization in comments.